### PR TITLE
fixed undefined single datepicker error

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -68,7 +68,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
         then moment(date).format(opts.locale.format)
         else date.format(opts.locale.format)
 
-      if opts.singleDatePicker and objValue
+      if opts.singleDatePicker
         f(objValue)
       else if objValue.startDate
         [f(objValue.startDate), f(objValue.endDate)].join(opts.locale.separator)


### PR DESCRIPTION
if single date picker is used but objValue is undefined we fallthrough to the else if branch and get `cannot read property startDate of undefined`